### PR TITLE
Update OneMessage.swift

### DIFF
--- a/Pod/Classes/OneMessage.swift
+++ b/Pod/Classes/OneMessage.swift
@@ -14,13 +14,13 @@ public typealias OneChatMessageCompletionHandler = (stream: XMPPStream, message:
 
 // MARK: Protocols
 
-public protocol OneMessageDelegate {
+public protocol OneMessageDelegate : NSObjectProtocol {
 	func oneStream(sender: XMPPStream, didReceiveMessage message: XMPPMessage, from user: XMPPUserCoreDataStorageObject)
 	func oneStream(sender: XMPPStream, userIsComposing user: XMPPUserCoreDataStorageObject)
 }
 
 public class OneMessage: NSObject {
-	public var delegate: OneMessageDelegate?
+	public weak var delegate: OneMessageDelegate?
 	
 	public var xmppMessageStorage: XMPPMessageArchivingCoreDataStorage?
 	var xmppMessageArchiving: XMPPMessageArchiving?


### PR DESCRIPTION
OneMessageDelegate must be NSObjectProtocol (otherwise the delegate can't be weak). 
And the delegate must be weak (for example: I use ViewController : OneMessageDelegate. Then deinit not called if I close this controller, because the delegate referred to my controller (strong link))
